### PR TITLE
use std::vec::Vec for headers_row

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ impl Json2Csv {
         }
 
         // Check that there are no collisions between flattened keys in different objects
-        let headers_row: BTreeSet<String> = headers
+        let headers_row: Vec<String> = headers
             .clone()
             .into_iter()
             .map(|x| self.transform_key(&x))
@@ -331,7 +331,7 @@ impl Json2Csv {
         }
 
         // Check that there are no collisions between flattened keys in different objects
-        let headers_row: BTreeSet<String> = headers
+        let headers_row: Vec<String> = headers
             .clone()
             .into_iter()
             .map(|x| self.transform_key(&x))


### PR DESCRIPTION
otherwise headers are resorted and data and header may no longer be
aligned correctly.

e.g. when we have `{"a" :[1,2,3], "a":{"b":2}}` and the flattener uses any
symbol do denote the array path which is sorted after dot (like the
symbol `[`) then usign a BTree for the headers_row potentially results
in resorting.